### PR TITLE
Better calendar view

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 cherrypy
 mongoengine >= 0.23.1
+python-dateutil >= 2.8.1

--- a/src/psij/testing/service.py
+++ b/src/psij/testing/service.py
@@ -258,10 +258,33 @@ class TestingAggregatorApp(object):
                 else:
                     month_data = site_data['months'][month]
 
+                branches = []
                 month_data[date_start.day] = {
                     'completed_count': total_completed,
-                    'failed_count': total_failed
+                    'failed_count': total_failed,
+                    'branches': branches
                 }
+
+
+                bs = {}
+                for env in envs:
+                    if env.branch not in bs:
+                        bs[env.branch] = {
+                            'completed_count': 0,
+                            'failed_count': 0
+                        }
+                    bs[env.branch]['completed_count'] += env.completed_count
+                    bs[env.branch]['failed_count'] += env.failed_count
+
+                for k, v in bs.items():
+                    branches.append({
+                        'completed_count': v['completed_count'],
+                        'failed_count': v['failed_count'],
+                        'name': k
+                    })
+
+
+
                 date_start = date_start + datetime.timedelta(days=-1)
 
 

--- a/src/psij/web/lib.js
+++ b/src/psij/web/lib.js
@@ -36,10 +36,16 @@ var settingsDefaults = function(dict) {
     }
 };
 
-var makeSetting = function(name, callback) {
+var makeSetting = function(name, callback, type) {
     return {
         get: function() {
-            return Cookies.get(name);
+            var val = Cookies.get(name);
+            if (type == "bool") {
+                return val == "true";
+            }
+            else {
+                return val;
+            }
         },
 
         set: function(val) {
@@ -58,6 +64,10 @@ var settings = function(...names) {
 
     return obj;
 };
+
+var setting = function(name) {
+    return Cookies.get(name);
+}
 
 var ansi_up = new AnsiUp();
 ansi_up.use_classes = true;
@@ -99,6 +109,9 @@ var globalMethods = {
         });
     },
     branchSort: function(lst) {
+        if (setting("showBranchBubbles") != "true") {
+            return lst.filter(branch => branch.name == "main");
+        }
         var sorted = lst.slice().sort((a, b) => {
             if (a.name == "main") {
                 // main goes first
@@ -109,7 +122,6 @@ var globalMethods = {
             }
             return a.name.localeCompare(b.name);
         });
-        console.log("Sorted: ", sorted);
         return sorted;
     },
     navigate: function(loc) {
@@ -344,7 +356,8 @@ var globalMethods = {
             b.push({text: "Run " + this.shortenId(this.run.run_id)})
         }
         return b;
-    }
+    },
+    setting: setting
 }
 
 $(document).ready(function() {

--- a/src/psij/web/lib.js
+++ b/src/psij/web/lib.js
@@ -98,6 +98,20 @@ var globalMethods = {
             return badness(a) - badness(b);
         });
     },
+    branchSort: function(lst) {
+        var sorted = lst.slice().sort((a, b) => {
+            if (a.name == "main") {
+                // main goes first
+                return -1;
+            }
+            if (b.name == "main") {
+                return 1;
+            }
+            return a.name.localeCompare(b.name);
+        });
+        console.log("Sorted: ", sorted);
+        return sorted;
+    },
     navigate: function(loc) {
         console.log(loc);
         return "event.stopPropagation(); window.location=\"" + loc + "\"";
@@ -249,16 +263,19 @@ var globalMethods = {
         }
         return days;
     },
-    calendarTileClass: function(site, day) {
+    calendarBubbleClass: function(site, day, branch) {
+        var size = function(branch) {
+            return branch.name == "main" ? "bubble-large" : "bubble-small";
+        }
         var d = getDayData(site, day);
         if (d == null || (d.completed_count == 0 && d.failed_count == 0)) {
-            return "state-unknown";
+            return "state-unknown, " + size(branch);
         }
         else {
-            return this.badnessClass(d);
+            return this.badnessClass(d) + ", " + size(branch);
         }
     },
-    calendarTileStyle: function(site, day) {
+    calendarBubbleStyle: function(site, day) {
         var d = getDayData(site, day);
         var color;
         if (d != null) {
@@ -310,6 +327,7 @@ var globalMethods = {
 
         return "background-color: " + color;
     },
+    getDayData: getDayData,
     breadcrumbs: function() {
         var b = [{text: "PSI/J Tests", href: "summary.html"}];
         var level = 0;

--- a/src/psij/web/style.css
+++ b/src/psij/web/style.css
@@ -488,11 +488,32 @@ td.run-id {
 }
 
 .calendar-tile {
-    width: 8pt;
-    height: 8pt;
     margin-left: auto;
     margin-right: auto;
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    height: 10pt;
+    align-content: center;
+}
+
+.calendar-bubble {
     border-radius: 100pt;
+    border: 0.5px solid rgba(0, 0, 0, 0.2);
+    display: inline-block;
+}
+
+.calendar-bubble.bubble-large {
+    width: 8pt;
+    height: 8pt;
+    margin-right: 2pt;
+}
+
+.calendar-bubble.bubble-small {
+    width: 3pt;
+    height: 3pt;
+    margin-right: 1pt;
+    margin-bottom: 1pt;
 }
 
 .calendar-tile.state-somewhat-bad {

--- a/src/psij/web/summary.html
+++ b/src/psij/web/summary.html
@@ -83,8 +83,11 @@
                     {{ site.site_id }}
                 </th>
                 <td class="calendar-cell" v-for="day in daysRange(now, 8)">
-                    <div class="calendar-tile" :class="calendarTileClass(site, day)" :style="calendarTileStyle(site, day)">
-                        &nbsp;
+                    <div class="calendar-tile">
+                        <div class="calendar-bubble" v-for="branch in branchSort(getDayData(site, day).branches)"
+                                   :class="calendarBubbleClass(site, day, branch)" :style="calendarBubbleStyle(site, day, branch)">
+                            &nbsp;
+                        </div>
                     </div>
                 </td>
             </tr>

--- a/src/psij/web/summary.html
+++ b/src/psij/web/summary.html
@@ -53,6 +53,12 @@
                                               suffix="days" v-model="inactiveTimeout"></v-text-field>
                             </v-col>
                         </v-row>
+                        <v-row>
+                            <v-col cols="12" sm="6" md="12">
+                                <v-checkbox label="Show branch bubbles in calendar view"
+                                              v-model="showBranchBubbles"></v-checkbox>
+                            </v-col>
+                        </v-row>
                     </v-container>
                 </v-card-text>
 
@@ -171,7 +177,7 @@
         var sites = [
         ];
 
-        settingsDefaults({"viewMode": "calendar", "inactiveTimeout": 10});
+        settingsDefaults({"viewMode": "calendar", "inactiveTimeout": 10, "showBranchBubbles": false});
 
         set = function(dst, src) {
             dst.length = 0;
@@ -200,6 +206,7 @@
             methods: globalMethods,
             computed: {
                 inactiveTimeout: makeSetting("inactiveTimeout", update),
+                showBranchBubbles: makeSetting("showBranchBubbles", update, "bool"),
                 allBranches: function() {
                     var unique = {};
                     for (var i = 0; i < this.sites.length; i++) {


### PR DESCRIPTION
This PR disables the calendar bubbles showing totals for all branches and, instead, allows for two options:
- main only (default) where only the status of the main branch is shown
- main and branches, where small bubbles with branch statuses are also shown

The main reason for this PR is that we don't want a bad PR from making it look like tests are failing all over the place when the main branch may very well have no issues.