### PR TITLE
Sort sites based on their fqdn. That is, split by '.' and give higher…

### DIFF
--- a/src/psij/web/lib.js
+++ b/src/psij/web/lib.js
@@ -100,6 +100,16 @@ var globalMethods = {
             return av > bv ? 1 : (av == bv) ? 0 : -1;
         });
     },
+    sitesSort: function(sites) {
+        var copy = sites.slice();
+        for (var i = 0; i < copy.length; i++) {
+            var site = copy[i];
+            site.key = site.site_id.split('.').reverse().join('.');
+            console.log(site.key)
+        }
+        strComp = function(a, b) {if (a > b) return 1; else if (a == b) return 0; else return -1;};
+        return copy.sort((a, b) => strComp(a.key, b.key));
+    },
     limit: function(array, n) {
         if (array.length > n) {
             return array.slice(0, n);

--- a/src/psij/web/summary.html
+++ b/src/psij/web/summary.html
@@ -83,7 +83,7 @@
                     <div class="calendar-day">{{ day.day }}</div>
                 </th>
             </tr>
-            <tr v-for="site in sort('site_id', sites)">
+            <tr v-for="site in sitesSort(sites)">
                 <th class="calendar-site highlightable clickable"
                     :onclick="navigate('site.html?site_id=' + site.site_id)">
                     {{ site.site_id }}


### PR DESCRIPTION
… priority to components at the end. For example, a.b comes *after* b.a because ".b" comes after ".a".

This should ensure that sites from the same domain are clustered together.